### PR TITLE
Update edX-plus-plus.user.js

### DIFF
--- a/Userscript/edX-plus-plus.user.js
+++ b/Userscript/edX-plus-plus.user.js
@@ -23,19 +23,7 @@
     var item = document.getElementsByClassName("video-speeds")[0];
     var new_speed = document.createElement("li");
     var btn = document.createElement("button");
-    var speed_limit = "2.0";
-    btn.setAttribute("class", "control speed-option");
-    btn.setAttribute("tabindex", -1);
-    btn.setAttribute("aria-pressed", "false");
-    new_speed.appendChild(btn);
-    new_speed.setAttribute("data-speed", speed_limit);
-    new_speed.children[0].innerText = speed_limit + "x";
-    item.prepend(new_speed);
-
-    item = document.getElementsByClassName("video-speeds")[0];
-    new_speed = document.createElement("li");
-    btn = document.createElement("button");
-    speed_limit = "2.5";
+    var speed_limit = "2.50";
     btn.setAttribute("class", "control speed-option");
     btn.setAttribute("tabindex", -1);
     btn.setAttribute("aria-pressed", "false");


### PR DESCRIPTION
Mimics the updates made to the script repo: https://github.com/EricPryzant/edX-Super-Speed/pull/2

Makes two fixes:

Edx now adds the 2x speed by default, so no need to double up.
Also now shows when 2.5x speed is selected

![image](https://user-images.githubusercontent.com/3886640/111570209-a93c6700-877a-11eb-899f-ac75dae30b0d.png)
